### PR TITLE
[DOS-88]

### DIFF
--- a/examples/nat/nat_example.go
+++ b/examples/nat/nat_example.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"time"
+
+	nat2 "github.com/DOSNetwork/core/p2p/nat"
+)
+
+var externalAddress net.IP
+var internalAddress net.IP
+var externalPort = 3323
+var internalPort = 9854
+var err error
+
+func server() {
+	private, err := nat2.IsPrivateIp()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if private {
+		fmt.Println("private ip detected, searching for nat device...")
+	} else {
+		fmt.Println("public ip, no nat needed")
+		os.Exit(0)
+	}
+
+	//use setMapping to search for nat device and build port mapping
+	nat, err := nat2.SetMapping("tcp", externalPort, internalPort, "DOSNode")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	externalAddress, err = nat.GetExternalAddress()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	internalAddress, err = nat.GetInternalAddress()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("external address: ", externalAddress)
+	fmt.Println("external port: ", externalPort)
+	fmt.Println("internal address: ", internalAddress)
+	fmt.Println("internal port: ", internalPort)
+	fmt.Println("nat type: ", nat.GetType())
+
+	address := internalAddress.String() + ":" + strconv.Itoa(internalPort)
+
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("server listening on ", address)
+
+	go client()
+
+	conn, err := listener.Accept()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("server accepts")
+
+	msg, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Print("server receive msg: ", msg)
+
+	conn.Write([]byte("echo " + msg))
+
+	conn.Close()
+	listener.Close()
+	nat.CloseMapping()
+
+}
+
+func client()  {
+	time.Sleep(2 * time.Second)
+	address := externalAddress.String() + ":" + strconv.Itoa(externalPort)
+	fmt.Println("client dialing ", address)
+	conn, err := net.Dial("tcp", address)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	conn.Write([]byte("hello\n"))
+
+	msg, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Print("client receive msg: ", msg)
+	conn.Close()
+}
+
+func main() {
+	server()
+}

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -1,0 +1,135 @@
+// Package nat implements NAT handling facilities
+package nat
+
+import (
+	"errors"
+	"log"
+	"net"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/netutil"
+	"github.com/jackpal/gateway"
+)
+
+const (
+	mapTimeout        = 20 * time.Minute
+	mapUpdateInterval = 15 * time.Minute
+)
+
+var ErrNoExternalAddress = errors.New("no external address")
+var ErrNoInternalAddress = errors.New("no internal address")
+var ErrNoNATFound = errors.New("no NAT found")
+
+// protocol is either "udp" or "tcp"
+type NAT interface {
+	// Type returns the kind of NAT port mapping service that is used
+	getType() string
+
+	// GetDeviceAddress returns the internal address of the gateway device.
+	getDeviceAddress() (addr net.IP, err error)
+
+	// GetExternalAddress returns the external address of the gateway device.
+	getExternalAddress() (addr net.IP, err error)
+
+	// GetInternalAddress returns the address of the local host.
+	getInternalAddress() (addr net.IP, err error)
+
+	// AddPortMapping maps a port on the local host to an external port.
+	addPortMapping(protocol string, externalPort, internalPort int, description string, timeout time.Duration) error
+
+	// DeletePortMapping removes a port mapping.
+	deletePortMapping(protocol string, internalPort int) (err error)
+}
+
+type natController struct {
+	natDevice NAT
+	c chan struct{}
+}
+
+func SetMapping(protocol string, extport, intport int, name string)  (*natController, error) {
+	nat, err := DiscoverGateway()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := nat.addPortMapping(protocol, extport, intport, name, mapTimeout); err != nil {
+		return nil, err
+	}
+
+	c := make(chan struct{})
+
+	go func() {
+
+		refresh := time.NewTimer(mapUpdateInterval)
+		defer func() {
+			refresh.Stop()
+			nat.deletePortMapping(protocol, intport)
+		}()
+
+		for {
+			select {
+			case _, ok := <-c:
+				if !ok {
+					return
+				}
+			case <-refresh.C:
+				if err := nat.addPortMapping(protocol, extport, intport, name, mapTimeout); err != nil {
+					log.Fatal(err)
+				}
+				refresh.Reset(mapUpdateInterval)
+			}
+		}
+
+	}()
+
+	return &natController{
+		natDevice:nat,
+		c:c,
+	}, nil
+}
+
+// DiscoverGateway attempts to find a gateway device.
+func DiscoverGateway() (NAT, error) {
+	select {
+	case nat := <-discoverUPNP_IG1():
+		return nat, nil
+	case nat := <-discoverUPNP_IG2():
+		return nat, nil
+	case nat := <-discoverNATPMP():
+		return nat, nil
+	case <-time.After(10 * time.Second):
+		return nil, ErrNoNATFound
+	}
+}
+
+func (natController *natController) CloseMapping() {
+	close(natController.c)
+	time.Sleep(2*time.Second)
+}
+
+func (natController *natController) GetDeviceAddress() (addr net.IP, err error) {
+	return natController.natDevice.getDeviceAddress()
+}
+
+func (natController *natController) GetExternalAddress() (addr net.IP, err error) {
+	return natController.natDevice.getExternalAddress()
+}
+
+func (natController *natController) GetInternalAddress() (addr net.IP, err error) {
+	return natController.natDevice.getInternalAddress()
+}
+
+func (natController *natController) GetType() string {
+	return natController.natDevice.getType()
+}
+
+func IsPrivateIp() (bool, error) {
+	ip, err := gateway.DiscoverGateway()
+	if err != nil {
+		return false, err
+	}
+
+	return netutil.IsLAN(ip), nil
+}
+
+

--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -1,0 +1,116 @@
+package nat
+
+import (
+	"net"
+	"time"
+
+	"github.com/jackpal/gateway"
+	"github.com/jackpal/go-nat-pmp"
+)
+
+var (
+	_ NAT = (*natpmpNAT)(nil)
+)
+
+func discoverNATPMP() <-chan NAT {
+	res := make(chan NAT, 1)
+
+	ip, err := gateway.DiscoverGateway()
+	if err == nil {
+		go discoverNATPMPWithAddr(res, ip)
+	}
+
+	return res
+}
+
+func discoverNATPMPWithAddr(c chan NAT, ip net.IP) {
+	client := natpmp.NewClient(ip)
+	_, err := client.GetExternalAddress()
+	if err != nil {
+		return
+	}
+
+	c <- &natpmpNAT{client, ip, make(map[int]int)}
+}
+
+type natpmpNAT struct {
+	c       *natpmp.Client
+	gateway net.IP
+	ports   map[int]int
+}
+
+func (n *natpmpNAT) getDeviceAddress() (addr net.IP, err error) {
+	return n.gateway, nil
+}
+
+func (n *natpmpNAT) getInternalAddress() (addr net.IP, err error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, addr := range addrs {
+			switch x := addr.(type) {
+			case *net.IPNet:
+				if x.Contains(n.gateway) {
+					return x.IP, nil
+				}
+			}
+		}
+	}
+
+	return nil, ErrNoInternalAddress
+}
+
+func (n *natpmpNAT) getExternalAddress() (addr net.IP, err error) {
+	res, err := n.c.GetExternalAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	d := res.ExternalIPAddress
+	return net.IPv4(d[0], d[1], d[2], d[3]), nil
+}
+
+func (n *natpmpNAT) addPortMapping(protocol string, externalPort, internalPort int, description string, timeout time.Duration) error {
+	n.deletePortMapping(protocol, internalPort)
+
+	var (
+		err error
+	)
+
+	timeoutInSeconds := int(timeout / time.Second)
+
+	if externalPort := n.ports[internalPort]; externalPort > 0 {
+		_, err = n.c.AddPortMapping(protocol, internalPort, externalPort, timeoutInSeconds)
+		if err == nil {
+			n.ports[internalPort] = externalPort
+			return nil
+		}
+	}
+
+	for i := 0; i < 3; i++ {
+		_, err = n.c.AddPortMapping(protocol, internalPort, externalPort, timeoutInSeconds)
+		if err == nil {
+			n.ports[internalPort] = externalPort
+			return nil
+		}
+	}
+
+	return err
+}
+
+func (n *natpmpNAT) deletePortMapping(protocol string, internalPort int) (err error) {
+	delete(n.ports, internalPort)
+	return nil
+}
+
+func (n *natpmpNAT) getType() string {
+	return "NAT-PMP"
+}

--- a/p2p/nat/upnp.go
+++ b/p2p/nat/upnp.go
@@ -1,0 +1,240 @@
+package nat
+
+import (
+	"net"
+	"time"
+
+	"github.com/huin/goupnp"
+	"github.com/huin/goupnp/dcps/internetgateway1"
+	"github.com/huin/goupnp/dcps/internetgateway2"
+)
+
+var (
+	_ NAT = (*upnp_NAT)(nil)
+)
+
+func discoverUPNP_IG1() <-chan NAT {
+	res := make(chan NAT, 1)
+	go func() {
+
+		// find devices
+		devs, err := goupnp.DiscoverDevices(internetgateway1.URN_WANConnectionDevice_1)
+		if err != nil {
+			return
+		}
+
+		for _, dev := range devs {
+			if dev.Root == nil {
+				continue
+			}
+
+			dev.Root.Device.VisitServices(func(srv *goupnp.Service) {
+				switch srv.ServiceType {
+				case internetgateway1.URN_WANIPConnection_1:
+					client := &internetgateway1.WANIPConnection1{ServiceClient: goupnp.ServiceClient{
+						SOAPClient: srv.NewSOAPClient(),
+						RootDevice: dev.Root,
+						Service:    srv,
+					}}
+					_, isNat, err := client.GetNATRSIPStatus()
+					if err == nil && isNat {
+						res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG1-IP1)", dev.Root}
+						return
+					}
+
+				case internetgateway1.URN_WANPPPConnection_1:
+					client := &internetgateway1.WANPPPConnection1{ServiceClient: goupnp.ServiceClient{
+						SOAPClient: srv.NewSOAPClient(),
+						RootDevice: dev.Root,
+						Service:    srv,
+					}}
+					_, isNat, err := client.GetNATRSIPStatus()
+					if err == nil && isNat {
+						res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG1-PPP1)", dev.Root}
+						return
+					}
+
+				}
+			})
+		}
+
+	}()
+	return res
+}
+
+func discoverUPNP_IG2() <-chan NAT {
+	res := make(chan NAT, 1)
+	go func() {
+
+		// find devices
+		devs, err := goupnp.DiscoverDevices(internetgateway2.URN_WANConnectionDevice_2)
+		if err != nil {
+			return
+		}
+
+		for _, dev := range devs {
+			if dev.Root == nil {
+				continue
+			}
+
+			dev.Root.Device.VisitServices(func(srv *goupnp.Service) {
+				switch srv.ServiceType {
+				case internetgateway2.URN_WANIPConnection_1:
+					client := &internetgateway2.WANIPConnection1{ServiceClient: goupnp.ServiceClient{
+						SOAPClient: srv.NewSOAPClient(),
+						RootDevice: dev.Root,
+						Service:    srv,
+					}}
+					_, isNat, err := client.GetNATRSIPStatus()
+					if err == nil && isNat {
+						res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG2-IP1)", dev.Root}
+						return
+					}
+
+				case internetgateway2.URN_WANIPConnection_2:
+					client := &internetgateway2.WANIPConnection2{ServiceClient: goupnp.ServiceClient{
+						SOAPClient: srv.NewSOAPClient(),
+						RootDevice: dev.Root,
+						Service:    srv,
+					}}
+					_, isNat, err := client.GetNATRSIPStatus()
+					if err == nil && isNat {
+						res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG2-IP2)", dev.Root}
+						return
+					}
+
+				case internetgateway2.URN_WANPPPConnection_1:
+					client := &internetgateway2.WANPPPConnection1{ServiceClient: goupnp.ServiceClient{
+						SOAPClient: srv.NewSOAPClient(),
+						RootDevice: dev.Root,
+						Service:    srv,
+					}}
+					_, isNat, err := client.GetNATRSIPStatus()
+					if err == nil && isNat {
+						res <- &upnp_NAT{client, make(map[int]int), "UPNP (IG2-PPP1)", dev.Root}
+						return
+					}
+
+				}
+			})
+		}
+
+	}()
+	return res
+}
+
+type upnp_NAT_Client interface {
+	GetExternalIPAddress() (string, error)
+	AddPortMapping(string, uint16, string, uint16, string, bool, string, uint32) error
+	DeletePortMapping(string, uint16, string) error
+}
+
+type upnp_NAT struct {
+	c          upnp_NAT_Client
+	ports      map[int]int
+	typ        string
+	rootDevice *goupnp.RootDevice
+}
+
+func (u *upnp_NAT) getExternalAddress() (addr net.IP, err error) {
+	ipString, err := u.c.GetExternalIPAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	ip := net.ParseIP(ipString)
+	if ip == nil {
+		return nil, ErrNoExternalAddress
+	}
+
+	return ip, nil
+}
+
+func mapProtocol(s string) string {
+	switch s {
+	case "udp":
+		return "UDP"
+	case "tcp":
+		return "TCP"
+	default:
+		panic("invalid protocol: " + s)
+	}
+}
+
+func (u *upnp_NAT) addPortMapping(protocol string, externalPort, internalPort int, description string, timeout time.Duration) error {
+	u.deletePortMapping(protocol, internalPort)
+
+	ip, err := u.getInternalAddress()
+	if err != nil {
+		return err
+	}
+
+	timeoutInSeconds := uint32(timeout / time.Second)
+
+	if externalPort := u.ports[internalPort]; externalPort > 0 {
+		err = u.c.AddPortMapping("", uint16(externalPort), mapProtocol(protocol), uint16(internalPort), ip.String(), true, description, timeoutInSeconds)
+		if err == nil {
+			return nil
+		}
+	}
+
+	for i := 0; i < 3; i++ {
+		err = u.c.AddPortMapping("", uint16(externalPort), mapProtocol(protocol), uint16(internalPort), ip.String(), true, description, timeoutInSeconds)
+		if err == nil {
+			u.ports[internalPort] = externalPort
+			return nil
+		}
+	}
+
+	return err
+}
+
+func (u *upnp_NAT) deletePortMapping(protocol string, internalPort int) error {
+	if externalPort := u.ports[internalPort]; externalPort > 0 {
+		delete(u.ports, internalPort)
+		return u.c.DeletePortMapping("", uint16(externalPort), mapProtocol(protocol))
+	}
+
+	return nil
+}
+
+func (u *upnp_NAT) getDeviceAddress() (net.IP, error) {
+	addr, err := net.ResolveUDPAddr("udp4", u.rootDevice.URLBase.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	return addr.IP, nil
+}
+
+func (u *upnp_NAT) getInternalAddress() (net.IP, error) {
+	devAddr, err := u.getDeviceAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, addr := range addrs {
+			switch x := addr.(type) {
+			case *net.IPNet:
+				if x.Contains(devAddr) {
+					return x.IP, nil
+				}
+			}
+		}
+	}
+
+	return nil, ErrNoInternalAddress
+}
+
+func (n *upnp_NAT) getType() string { return n.typ }


### PR DESCRIPTION
1. Add NAT device searching and mapping functions to p2p module, in
order to provide LAN devices WAN connectivity by mapping a private port
to a public port.

2. Example is added to /example/nat/nat_example.go

Please use `$ go run nat_example.go` to run the file.