### PR TITLE
[DOS-91]

### DIFF
--- a/examples/p2p/main.go
+++ b/examples/p2p/main.go
@@ -23,7 +23,7 @@ func main() {
 	p, _ := p2p.CreateP2PNetwork(tunnel)
 	defer close(tunnel)
 	//2)Start to listen incoming connection
-	go p.Listen()
+	p.Listen()
 
 	//3)Dial to peers to build peerClient
 	if *connect != "" {

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -4,6 +4,8 @@ package nat
 import (
 	"errors"
 	"log"
+	"math"
+	"math/rand"
 	"net"
 	"time"
 
@@ -132,4 +134,8 @@ func IsPrivateIp() (bool, error) {
 	return netutil.IsLAN(ip), nil
 }
 
+func RandomPort() int {
+	rand.Seed(time.Now().UnixNano())
+	return rand.Intn(math.MaxUint16-10000) + 10000
+}
 


### PR DESCRIPTION
1. Add randomPort func to nat.go in order to allow multiple devices use
the same NAT device by assigning various externalPort

2. Add NAT service to p2p.go to let the P2P module automatically obtain
a public IP address

3. Modify /example/p2p/main.go to adopt NAT.