### PR TITLE
Revert "Use eth account address as node id"

### DIFF
--- a/blockchain/eth/eth_proxy.go
+++ b/blockchain/eth/eth_proxy.go
@@ -587,8 +587,7 @@ func (e *EthAdaptor) setAccount(autoReplenish bool) (err error) {
 
 	e.key = usrKey
 	e.id = new(big.Int)
-	idBytes := append(new([12]byte)[:], e.key.Address.Bytes()...)
-	e.id.SetBytes(idBytes)
+	e.id.SetBytes([]byte(e.key.Id.String()))
 
 	if autoReplenish {
 		var rootKeyPath string


### PR DESCRIPTION
Reverts DOSNetwork/core#36